### PR TITLE
Use HTML entities instead of angle brackets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ ENV/
 .cache/
 node_modules/
 public/
+
+*.code-workspace

--- a/github-metrics/src/components/dashboard.js
+++ b/github-metrics/src/components/dashboard.js
@@ -313,7 +313,7 @@ const Dashboard = () => {
     return (
       <div css={styles.filterDescription}>
         <FilterAltIcon css={styles.filterIcon}/> Showing {repoData.length} repositories {
-        isCuratedField(filterValues["field_of_study"]) ? <span>related to {cleanField}{suffix}.<HelpTooltip iconStyle={helpStyle} text={<span>This list is based on {sources[filterValues["field_of_study"]]}. <ExternalLink href={'https://eto.tech/tool-docs/orca/#manually-compiled-fields'}>Read more >></ExternalLink></span>}/></span> :
+        isCuratedField(filterValues["field_of_study"]) ? <span>related to {cleanField}{suffix}.<HelpTooltip iconStyle={helpStyle} text={<span>This list is based on {sources[filterValues["field_of_study"]]}. <ExternalLink href={'https://eto.tech/tool-docs/orca/#manually-compiled-fields'}>Read more &gt;&gt;</ExternalLink></span>}/></span> :
           <span>mentioned in {cleanField} articles in our dataset{suffix}<span style={styles.nowrap}>.<HelpTooltip iconStyle={helpStyle} text={getTooltip("number_of_mentions", "#SUBJECT", cleanField)}/></span></span>
           }
       </div>

--- a/github-metrics/src/pages/index.js
+++ b/github-metrics/src/pages/index.js
@@ -38,7 +38,7 @@ const IndexPage = () => {
         title={<div style={{fontFamily: "GTZirkonBold, sans-serif !important"}}>🌊 ORCA: OSS Research and Community Activity</div>}
         description={<div>
           <div style={{marginBottom: "10px"}}>
-          ORCA compiles data on open-source software (OSS) used in science and technology research. Drawing on Github Archive, ETO’s Merged Academic Corpus, and many other data sources, ORCA tracks OSS usage, health, development activity, and community engagement across a wide range of software projects and research subjects. Use ORCA to compare OSS projects in a particular research area, track trends over time, and sort and filter projects by different metrics. <ExternalLink href={"https://eto.tech/tool-docs/orca"}>Read the docs >></ExternalLink>
+          ORCA compiles data on open-source software (OSS) used in science and technology research. Drawing on Github Archive, ETO’s Merged Academic Corpus, and many other data sources, ORCA tracks OSS usage, health, development activity, and community engagement across a wide range of software projects and research subjects. Use ORCA to compare OSS projects in a particular research area, track trends over time, and sort and filter projects by different metrics. <ExternalLink href={"https://eto.tech/tool-docs/orca"}>Read the docs &gt;&gt;</ExternalLink>
           </div>
           <div>
             Website last updated on {data.site.buildTime}. Data last updated on {config.last_updated}.


### PR DESCRIPTION
Using raw angle brackets in this case leads to 'unexpected token' warnings, whereas using `&gt;` makes it clear that this isn't meant to be part of an HTML tag.

Alternatively, we could use a MUI icon such as
https://mui.com/material-ui/material-icons/?query=right&selected=KeyboardDoubleArrowRight

Also ignored VSCode workspace files