### PR TITLE
Resolve unintentional bolding of Dropdown label

### DIFF
--- a/github-metrics/src/components/summary.js
+++ b/github-metrics/src/components/summary.js
@@ -20,6 +20,10 @@ const styles = {
     vertical-align: bottom;
     font-weight: bold;
     padding-bottom: 16px;
+
+    & .dropdown label {
+      font-weight: normal;
+    }
   `,
   dropdownContainer: css`
     display: inline-block;


### PR DESCRIPTION
Excepted the Dropdown's label from being bolded when within a header.

Closes #280