### PR TITLE
Improve test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ ENV/
 
 # Frontend
 .cache/
+coverage/
 node_modules/
 public/
 

--- a/github-metrics/jest.config.js
+++ b/github-metrics/jest.config.js
@@ -29,6 +29,7 @@ module.exports = {
   collectCoverage: true,
   collectCoverageFrom: [
     'src/**/*.{js,jsx}',
+    '!src/pages/*',
     '!**/*.test.*',
     '!**/__tests__/**',
   ],

--- a/github-metrics/package-lock.json
+++ b/github-metrics/package-lock.json
@@ -28,8 +28,9 @@
         "react-plotly.js": "^2.6.0"
       },
       "devDependencies": {
-        "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/jest-dom": "^6.4.2",
+        "@testing-library/react": "^14.2.1",
+        "@testing-library/user-event": "^14.5.2",
         "@types/jest": "^29.2.3",
         "babel-jest": "^29.5.0",
         "babel-preset-gatsby": "^3.7.0",
@@ -40,9 +41,9 @@
       }
     },
     "node_modules/@adobe/css-tools": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.0.1.tgz",
-      "integrity": "sha512-+u76oB43nOHrF4DDWRLWDCtci7f3QJoEBigemIdIeTi1ODqjx6Tad9NCVnPRwewWlKkVab5PlK8DCtPTyX7S8g==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.3.tgz",
+      "integrity": "sha512-rE0Pygv0sEZ4vBWHlAgJLGDU7Pm8xoO6p3wsEceb7GYAjScrOHpEo8KK/eVkAcnSM+slAEtXjA2JpdjLp4fJQQ==",
       "dev": true
     },
     "node_modules/@ampproject/remapping": {
@@ -4823,44 +4824,67 @@
       }
     },
     "node_modules/@testing-library/dom": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.19.0.tgz",
-      "integrity": "sha512-6YWYPPpxG3e/xOo6HIWwB/58HukkwIVTOaZ0VwdMVjhRUX/01E4FtQbck9GazOOj7MXHc5RBzMrU86iBJHbI+A==",
+      "version": "9.3.4",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.4.tgz",
+      "integrity": "sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^4.2.0",
-        "aria-query": "^5.0.0",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.1.3",
         "chalk": "^4.1.0",
         "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.4.4",
+        "lz-string": "^1.5.0",
         "pretty-format": "^27.0.2"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/@testing-library/jest-dom": {
-      "version": "5.16.5",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.16.5.tgz",
-      "integrity": "sha512-N5ixQ2qKpi5OLYfwQmUb/5mSV9LneAcaUfp32pn4yCnpb8r/Yz0pXFPck21dIicKmi+ta5WRAknkZCfA8refMA==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.4.2.tgz",
+      "integrity": "sha512-CzqH0AFymEMG48CpzXFriYYkOjk6ZGPCLMhW9e9jg3KMCn5OfJecF8GtGW7yGfR/IgCe3SX8BSwjdzI6BBbZLw==",
       "dev": true,
       "dependencies": {
-        "@adobe/css-tools": "^4.0.1",
+        "@adobe/css-tools": "^4.3.2",
         "@babel/runtime": "^7.9.2",
-        "@types/testing-library__jest-dom": "^5.9.1",
         "aria-query": "^5.0.0",
         "chalk": "^3.0.0",
         "css.escape": "^1.5.1",
-        "dom-accessibility-api": "^0.5.6",
+        "dom-accessibility-api": "^0.6.3",
         "lodash": "^4.17.15",
         "redent": "^3.0.0"
       },
       "engines": {
-        "node": ">=8",
+        "node": ">=14",
         "npm": ">=6",
         "yarn": ">=1"
+      },
+      "peerDependencies": {
+        "@jest/globals": ">= 28",
+        "@types/bun": "latest",
+        "@types/jest": ">= 28",
+        "jest": ">= 28",
+        "vitest": ">= 0.32"
+      },
+      "peerDependenciesMeta": {
+        "@jest/globals": {
+          "optional": true
+        },
+        "@types/bun": {
+          "optional": true
+        },
+        "@types/jest": {
+          "optional": true
+        },
+        "jest": {
+          "optional": true
+        },
+        "vitest": {
+          "optional": true
+        }
       }
     },
     "node_modules/@testing-library/jest-dom/node_modules/ansi-styles": {
@@ -4909,6 +4933,12 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true
+    },
     "node_modules/@testing-library/jest-dom/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -4931,21 +4961,34 @@
       }
     },
     "node_modules/@testing-library/react": {
-      "version": "13.4.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-13.4.0.tgz",
-      "integrity": "sha512-sXOGON+WNTh3MLE9rve97ftaZukN3oNf2KjDy7YTx6hcTO2uuLHuCGynMDhFwGw/jYf4OJ2Qk0i4i79qMNNkyw==",
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-14.2.1.tgz",
+      "integrity": "sha512-sGdjws32ai5TLerhvzThYFbpnF9XtL65Cjf+gB0Dhr29BGqK+mAeN7SURSdu+eqgET4ANcWoC7FQpkaiGvBr+A==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
-        "@testing-library/dom": "^8.5.0",
+        "@testing-library/dom": "^9.0.0",
         "@types/react-dom": "^18.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       },
       "peerDependencies": {
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.5.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.5.2.tgz",
+      "integrity": "sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tokenizer/token": {
@@ -5050,9 +5093,9 @@
       }
     },
     "node_modules/@types/aria-query": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.2.tgz",
-      "integrity": "sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true
     },
     "node_modules/@types/babel__core": {
@@ -5460,15 +5503,6 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
-    },
-    "node_modules/@types/testing-library__jest-dom": {
-      "version": "5.14.5",
-      "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.5.tgz",
-      "integrity": "sha512-SBwbxYoyPIvxHbeHxTZX2Pe/74F/tX2/D3mMvzabdeJ25bBojfW0TyB8BHrbq/9zaaKICJZjLP+8r6AeZMFCuQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/jest": "*"
-      }
     },
     "node_modules/@types/tmp": {
       "version": "0.0.33",
@@ -7217,9 +7251,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001439",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001439.tgz",
-      "integrity": "sha512-1MgUzEkoMO6gKfXflStpYgZDlFM7M/ck/bgfVCACO5vnAf0fXoNVHdWtqGU+MYca+4bL9Z5bpOVmR33cWW9G2A==",
+      "version": "1.0.30001588",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001588.tgz",
+      "integrity": "sha512-+hVY9jE44uKLkH0SrUTqxjxqNTOWHsbnQDIKjwkZ3lNTzUUVdBLBGXtj/q5Mp5u98r3droaZAewQuEDzjQdZlQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -7228,6 +7262,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ]
     },
@@ -17224,9 +17262,9 @@
       }
     },
     "node_modules/lz-string": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
-      "integrity": "sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "bin": {
         "lz-string": "bin/bin.js"
@@ -25048,9 +25086,9 @@
   },
   "dependencies": {
     "@adobe/css-tools": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.0.1.tgz",
-      "integrity": "sha512-+u76oB43nOHrF4DDWRLWDCtci7f3QJoEBigemIdIeTi1ODqjx6Tad9NCVnPRwewWlKkVab5PlK8DCtPTyX7S8g==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.3.tgz",
+      "integrity": "sha512-rE0Pygv0sEZ4vBWHlAgJLGDU7Pm8xoO6p3wsEceb7GYAjScrOHpEo8KK/eVkAcnSM+slAEtXjA2JpdjLp4fJQQ==",
       "dev": true
     },
     "@ampproject/remapping": {
@@ -28399,34 +28437,33 @@
       }
     },
     "@testing-library/dom": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.19.0.tgz",
-      "integrity": "sha512-6YWYPPpxG3e/xOo6HIWwB/58HukkwIVTOaZ0VwdMVjhRUX/01E4FtQbck9GazOOj7MXHc5RBzMrU86iBJHbI+A==",
+      "version": "9.3.4",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.4.tgz",
+      "integrity": "sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^4.2.0",
-        "aria-query": "^5.0.0",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.1.3",
         "chalk": "^4.1.0",
         "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.4.4",
+        "lz-string": "^1.5.0",
         "pretty-format": "^27.0.2"
       }
     },
     "@testing-library/jest-dom": {
-      "version": "5.16.5",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.16.5.tgz",
-      "integrity": "sha512-N5ixQ2qKpi5OLYfwQmUb/5mSV9LneAcaUfp32pn4yCnpb8r/Yz0pXFPck21dIicKmi+ta5WRAknkZCfA8refMA==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.4.2.tgz",
+      "integrity": "sha512-CzqH0AFymEMG48CpzXFriYYkOjk6ZGPCLMhW9e9jg3KMCn5OfJecF8GtGW7yGfR/IgCe3SX8BSwjdzI6BBbZLw==",
       "dev": true,
       "requires": {
-        "@adobe/css-tools": "^4.0.1",
+        "@adobe/css-tools": "^4.3.2",
         "@babel/runtime": "^7.9.2",
-        "@types/testing-library__jest-dom": "^5.9.1",
         "aria-query": "^5.0.0",
         "chalk": "^3.0.0",
         "css.escape": "^1.5.1",
-        "dom-accessibility-api": "^0.5.6",
+        "dom-accessibility-api": "^0.6.3",
         "lodash": "^4.17.15",
         "redent": "^3.0.0"
       },
@@ -28465,6 +28502,12 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
+        "dom-accessibility-api": {
+          "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+          "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+          "dev": true
+        },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -28483,15 +28526,22 @@
       }
     },
     "@testing-library/react": {
-      "version": "13.4.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-13.4.0.tgz",
-      "integrity": "sha512-sXOGON+WNTh3MLE9rve97ftaZukN3oNf2KjDy7YTx6hcTO2uuLHuCGynMDhFwGw/jYf4OJ2Qk0i4i79qMNNkyw==",
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-14.2.1.tgz",
+      "integrity": "sha512-sGdjws32ai5TLerhvzThYFbpnF9XtL65Cjf+gB0Dhr29BGqK+mAeN7SURSdu+eqgET4ANcWoC7FQpkaiGvBr+A==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.12.5",
-        "@testing-library/dom": "^8.5.0",
+        "@testing-library/dom": "^9.0.0",
         "@types/react-dom": "^18.0.0"
       }
+    },
+    "@testing-library/user-event": {
+      "version": "14.5.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.5.2.tgz",
+      "integrity": "sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==",
+      "dev": true,
+      "requires": {}
     },
     "@tokenizer/token": {
       "version": "0.3.0",
@@ -28571,9 +28621,9 @@
       }
     },
     "@types/aria-query": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.2.tgz",
-      "integrity": "sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true
     },
     "@types/babel__core": {
@@ -28974,15 +29024,6 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
-    },
-    "@types/testing-library__jest-dom": {
-      "version": "5.14.5",
-      "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.5.tgz",
-      "integrity": "sha512-SBwbxYoyPIvxHbeHxTZX2Pe/74F/tX2/D3mMvzabdeJ25bBojfW0TyB8BHrbq/9zaaKICJZjLP+8r6AeZMFCuQ==",
-      "dev": true,
-      "requires": {
-        "@types/jest": "*"
-      }
     },
     "@types/tmp": {
       "version": "0.0.33",
@@ -30298,9 +30339,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001439",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001439.tgz",
-      "integrity": "sha512-1MgUzEkoMO6gKfXflStpYgZDlFM7M/ck/bgfVCACO5vnAf0fXoNVHdWtqGU+MYca+4bL9Z5bpOVmR33cWW9G2A=="
+      "version": "1.0.30001588",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001588.tgz",
+      "integrity": "sha512-+hVY9jE44uKLkH0SrUTqxjxqNTOWHsbnQDIKjwkZ3lNTzUUVdBLBGXtj/q5Mp5u98r3droaZAewQuEDzjQdZlQ=="
     },
     "canvas-fit": {
       "version": "1.5.0",
@@ -37833,9 +37874,9 @@
       }
     },
     "lz-string": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
-      "integrity": "sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true
     },
     "make-dir": {

--- a/github-metrics/package.json
+++ b/github-metrics/package.json
@@ -38,8 +38,9 @@
     "react-plotly.js": "^2.6.0"
   },
   "devDependencies": {
-    "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/user-event": "^14.5.2",
     "@types/jest": "^29.2.3",
     "babel-jest": "^29.5.0",
     "babel-preset-gatsby": "^3.7.0",

--- a/github-metrics/package.json
+++ b/github-metrics/package.json
@@ -7,7 +7,7 @@
     "gatsby"
   ],
   "scripts": {
-    "develop": "gatsby develop",
+    "develop": "gatsby develop -p 8560",
     "start": "gatsby develop",
     "build": "NODE_OPTIONS=--max-old-space-size=8192 gatsby build",
     "serve": "NODE_OPTIONS=--max-old-space-size=8192 gatsby serve",

--- a/github-metrics/src/components/dashboard.js
+++ b/github-metrics/src/components/dashboard.js
@@ -323,10 +323,10 @@ const Dashboard = () => {
   return (
     <div style={{backgroundColor: "white"}} id={"dashboard"} ref={contentContainer}>
       <div>
-        <div css={styles.topPanel}>
+        <div css={styles.topPanel} data-testid="top-panel">
           <div css={styles.filterContainer}>
             <div>
-              <div css={[styles.dropdownContainer, styles.topicContainer]}>
+              <div css={[styles.dropdownContainer, styles.topicContainer]} data-testid="research-field-wrapper">
                 <Autocomplete
                   selected={filterValues["field_of_study"]}
                   setSelected={(val) => handleSingleSelectChange(val, "field_of_study")}

--- a/github-metrics/src/components/dashboard.js
+++ b/github-metrics/src/components/dashboard.js
@@ -28,7 +28,7 @@ import {
   sources,
   helpStyle,
   getTooltip
-} from "./utils";
+} from "../util";
 
 const setFields = new Set(fields);
 

--- a/github-metrics/src/components/dashboard.js
+++ b/github-metrics/src/components/dashboard.js
@@ -314,7 +314,7 @@ const Dashboard = () => {
       <div css={styles.filterDescription}>
         <FilterAltIcon css={styles.filterIcon}/> Showing {repoData.length} repositories {
         isCuratedField(filterValues["field_of_study"]) ? <span>related to {cleanField}{suffix}.<HelpTooltip iconStyle={helpStyle} text={<span>This list is based on {sources[filterValues["field_of_study"]]}. <ExternalLink href={'https://eto.tech/tool-docs/orca/#manually-compiled-fields'}>Read more &gt;&gt;</ExternalLink></span>}/></span> :
-          <span>mentioned in {cleanField} articles in our dataset{suffix}<span style={styles.nowrap}>.<HelpTooltip iconStyle={helpStyle} text={getTooltip("number_of_mentions", "#SUBJECT", cleanField)}/></span></span>
+          <span>mentioned in {cleanField} articles in our dataset{suffix}<span css={styles.nowrap}>.<HelpTooltip iconStyle={helpStyle} text={getTooltip("number_of_mentions", "#SUBJECT", cleanField)}/></span></span>
           }
       </div>
     )

--- a/github-metrics/src/components/dashboard.test.js
+++ b/github-metrics/src/components/dashboard.test.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import { screen, act, getAllByRole, getByRole } from '@testing-library/react';
+
+import Dashboard from './dashboard';
+import { userEventSetup } from '../util/testing';
+
+window.HTMLElement.prototype.scrollIntoView = jest.fn();
+
+const currentlyTrackingHeading = (num, field) => {
+  return `Currently tracking ${num} software repositories mentioned in research into ${field} .`;
+}
+
+describe("filter panel", () => {
+  it("switches research fields", async () => {
+    const { user } = userEventSetup(
+      <Dashboard />
+    );
+
+    let topReposHeading;
+    let topEntries
+
+    expect(screen.getByRole("heading", { name: currentlyTrackingHeading(413, "artificial intelligence") })).toBeVisible();
+    topReposHeading = screen.getByRole("heading", { name: "Top repositories by stars" });
+    topEntries = getAllByRole(topReposHeading.parentElement, "listitem");
+    expect(topEntries[0].textContent).toEqual("facebook/react215865 stars (-32.65%, 2022-2023)");
+    expect(topEntries[1].textContent).toEqual("tensorflow/tensorflow179194 stars (-11.62%, 2022-2023)");
+
+    await user.click(screen.getByRole('combobox'));
+    expect(screen.getByText("Astrobiology")).toBeVisible();
+    await act(() => {
+      user.click(screen.getByText("Astrobiology"));
+    });
+    await new Promise(res => setTimeout(res, 500));
+
+    expect(screen.getByRole("heading", { name: currentlyTrackingHeading(59, "astrobiology") })).toBeVisible();
+    topReposHeading = screen.getByRole("heading", { name: "Top repositories by stars" });
+    topEntries = getAllByRole(topReposHeading.parentElement, "listitem");
+    expect(topEntries[0].textContent).toEqual("astropy/astropy4028 stars (-46.90%, 2022-2023)");
+    expect(topEntries[1].textContent).toEqual("dfm/emcee1384 stars (-16.50%, 2022-2023)");
+  });
+
+
+  it("toggles between summary and list view", async () => {
+    const { user } = userEventSetup(
+      <Dashboard />
+    );
+
+    expect(screen.getByRole("heading", { name: currentlyTrackingHeading(59, "astrobiology") })).toBeVisible();
+
+    await user.click(screen.getByRole('checkbox'));
+    await new Promise(res => setTimeout(res, 500));
+
+    expect(screen.getByRole("button", { name: "Show Filters" })).toBeVisible();
+
+    const cards = screen.getAllByTestId("project-card");
+    expect(getByRole(cards[0], "heading", { name: "hannorein/rebound" })).toBeVisible();
+    expect(cards[0].textContent).toContain("Stars: 570");
+    expect(cards[0].textContent).toContain("Top Programming Language: C");
+    expect(getByRole(cards[1], "heading", { name: "jlillo/tpfplotter" })).toBeVisible();
+    expect(cards[1].textContent).toContain("Date created: 2020-02-02");
+    expect(cards[1].textContent).toContain("License: MIT License");
+  });
+});

--- a/github-metrics/src/components/project_card.js
+++ b/github-metrics/src/components/project_card.js
@@ -92,7 +92,7 @@ const ProjectCard = (props) => {
   };
 
   return (
-    <div css={styles.card}>
+    <div css={styles.card} data-testid="project-card">
       <div css={styles.metadataContainer}>
         <div css={styles.leftPanel}>
           <span>

--- a/github-metrics/src/components/project_card.js
+++ b/github-metrics/src/components/project_card.js
@@ -11,9 +11,8 @@ import "core-js/features/url-search-params";
 
 import {LineGraph, BarGraph} from "./graph";
 import ProjectMetadata from "./project_metadata";
-
-import {getCountryTraces, getBarTraces, getX, getY, getRepoName} from "./utils";
 import githubLogo from "../images/github-mark.png";
+import {getCountryTraces, getBarTraces, getX, getY, getRepoName} from "../util";
 
 
 const styles = {

--- a/github-metrics/src/components/project_details.js
+++ b/github-metrics/src/components/project_details.js
@@ -2,21 +2,29 @@
 Component containing repo detail view
  */
 import React, {useEffect} from "react";
+import {css} from "@emotion/react";
+import LaunchIcon from "@mui/icons-material/Launch";
 
 import "core-js/features/url";
 import "core-js/features/url-search-params";
 
+import {Accordion, ExternalLink, HelpTooltip} from "@eto/eto-ui-components";
+
+import {BarGraph, LineGraph} from "./graph";
+import HighlightBox from "./highlight_box";
+import ProjectMetadata from "./project_metadata";
 import id_to_repo from "../data/id_to_repo";
 import name_to_id from "../data/name_to_id";
-import {Accordion, ExternalLink, HelpTooltip} from "@eto/eto-ui-components";
-import {css} from "@emotion/react";
-import LaunchIcon from "@mui/icons-material/Launch";
-import {BarGraph, LineGraph} from "./graph";
-import ProjectMetadata from "./project_metadata";
-
-import {keyToTitle, getCountryTraces, getBarTraces, getX, getY, getRepoName, getTooltip} from "./utils";
-import HighlightBox from "./highlight_box";
 import githubLogo from "../images/github-mark.png";
+import {
+  getBarTraces,
+  getCountryTraces,
+  getX,
+  getY,
+  getRepoName,
+  getTooltip,
+  keyToTitle,
+} from "../util";
 
 const styles = {
   dashboardContainer: css`

--- a/github-metrics/src/components/project_metadata.js
+++ b/github-metrics/src/components/project_metadata.js
@@ -5,12 +5,16 @@ import React from "react";
 import { css } from "@emotion/react";
 
 import {HelpTooltip} from "@eto/eto-ui-components";
-import {helpStyle, getTooltip} from "./utils";
+import {
+  FIELD_KEYS,
+  cleanFieldName,
+  helpStyle,
+  getTooltip,
+  metaMapping,
+} from "../util";
 
 import "core-js/features/url";
 import "core-js/features/url-search-params";
-
-import {cleanFieldName, FIELD_KEYS, metaMapping} from "./utils";
 
 
 const styles = {

--- a/github-metrics/src/components/project_metadata.js
+++ b/github-metrics/src/components/project_metadata.js
@@ -63,7 +63,7 @@ const ProjectMetadata = (props) => {
           {group.map(option => ((showNumReferences) || (option !== "num_references")) && (
             <span css={styles.metaSection} key={option}>
               {option === "num_references" ?
-                <span>{getValue(option)} mentions in <strong>{cleanFieldName(field)}</strong> articles ({getValue("relevance").toFixed(2)} <span css={styles.nowrap}>relevance<HelpTooltip style={helpStyle} text={getTooltip("relevance_list")}/>)</span></span>
+                <span>{getValue(option)} mentions in <strong>{cleanFieldName(field)}</strong> articles ({getValue("relevance").toFixed(2)} <span css={styles.nowrap}>relevance<HelpTooltip iconStyle={helpStyle} text={getTooltip("relevance_list")}/>)</span></span>
               :
                 <span><strong>{metaMapping[option]}</strong>: {getValue(option)}</span>
               }

--- a/github-metrics/src/components/summary.js
+++ b/github-metrics/src/components/summary.js
@@ -2,13 +2,21 @@
 Summary metrics for top five repositories within current selection
  */
 import React, {useEffect} from "react";
-
-import {LineGraph} from "./graph";
 import {css} from "@emotion/react";
 
-import {keyToTitle, sortMappingBlurb, getRepoName, sortByKey, cleanFieldName, FIELD_KEYS, getTooltip} from "./utils";
-import HighlightBox from "./highlight_box";
 import {Accordion, Dropdown, ExternalLink, HelpTooltip} from "@eto/eto-ui-components";
+
+import { LineGraph } from "./graph";
+import HighlightBox from "./highlight_box";
+import {
+  FIELD_KEYS,
+  cleanFieldName,
+  getRepoName,
+  getTooltip,
+  keyToTitle,
+  sortByKey,
+  sortMappingBlurb,
+} from "../util";
 
 
 const styles = {

--- a/github-metrics/src/util/index.js
+++ b/github-metrics/src/util/index.js
@@ -30,7 +30,7 @@ export const getTooltip = (key, replFrom=null, replTo=null) => {
   if(replFrom !== null){
     ttText = ttText.replace(replFrom, replTo);
   }
-  return <span>{ttText}{key in tooltipLinks && <span> <ExternalLink href={tooltipLinks[key]}>Read more >></ExternalLink></span>}</span>;
+  return <span>{ttText}{key in tooltipLinks && <span> <ExternalLink href={tooltipLinks[key]}>Read more &gt;&gt;</ExternalLink></span>}</span>;
 };
 
 export const helpStyle = {verticalAlign: "middle", marginBottom: "2px"};

--- a/github-metrics/src/util/index.test.js
+++ b/github-metrics/src/util/index.test.js
@@ -1,5 +1,5 @@
 import React from "react"
-import {getCountryTraces, getBarTraces} from "../utils"
+import {getCountryTraces, getBarTraces} from "./index"
 
 describe("getCountryTraces", () => {
   it("has expected output", () => {

--- a/github-metrics/src/util/testing.js
+++ b/github-metrics/src/util/testing.js
@@ -1,0 +1,9 @@
+import { render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+export function userEventSetup(jsx) {
+  return {
+    user: userEvent.setup(),
+    ...render(jsx),
+  }
+}


### PR DESCRIPTION
* Add tests for the filter/selection panel on the main dashboard testing changing the research field, switching to list view, adjusting the sort criteria and graphs, filtering by programming language and license, and finally resetting the filters
* Don't run test coverage over pages since we test the components separately
* Relocate the `src/components/utils.js` file to a new `src/util/` directory since utilities aren't really components
* Update deprecated and typoed props, testing dependencies, and the browserslist database