### PR TITLE
Don't trigger CI workflows after Dependabot actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,7 @@ jobs:
   build:
     name: tests-pass
     runs-on: ubuntu-latest
+    if: github.triggering_actor != 'dependabot[bot]'
 
     permissions:
       contents: 'read'

--- a/.github/workflows/visual-testing.yml
+++ b/.github/workflows/visual-testing.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       app-dir: ./github-metrics
+    if: github.triggering_actor != 'dependabot[bot]'
 
     permissions:
       contents: 'read'


### PR DESCRIPTION
This should still allow non-Dependabot users to manually trigger the actions for Dependabot-created PRs, per https://stackoverflow.com/a/71854535