### PR TITLE
Upload final set of repos to be displayed in orca to BQ for use in Map of Science

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Run `PYTHONPATH='.' python3 scripts/retrieve_repo_metadata.py curr_repos_filled.
 the sequence of queries in `sequences/downstream_order.txt`. Assuming your dataset in BigQuery is called `orca`, download
 the data from
 `orca.website_stats` in BigQuery as JSONL,
-then run `PYTHONPATH='.' python3 scripts/preprocess_for_website.py --input_dir <path to your downloaded data>`.
+then run `PYTHONPATH='.' python3 scripts/preprocess_for_website.py`.
 
 These steps are automated and run on a monthly basis on the scholarly literature data using the `orca_data_pipeline.py`
 Airflow pipeline.


### PR DESCRIPTION
Part of https://github.com/georgetown-cset/science_map_ui/issues/1005

To add links to ORCA to the MoS we need to be able to tell which repos are displayed in ORCA (and consequently satisfy a bunch of selection criteria) vs are just mentioned in some research paper. These updates add a new BigQuery table with the final set of repos that are displayed in ORCA which we'll use in MoS to decide whether to link to ORCA or GitHub