### PR TITLE
Specify author of data update PRs

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -38,4 +38,5 @@ jobs:
             github-metrics/static/*
           token: ${{ secrets.GITHUB_TOKEN }}
           title: Data update
+          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           reviewers: jmelot


### PR DESCRIPTION
Without explicitly setting an `author`, the workflow defaults to saying that I created the data update PRs (which I didn't), presumably because I was the one who merged the PR creating this workflow.