### PR TITLE
Format deploy script and track deployment commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 This repository contains code related to the ORCA project.
 
-## Running the ORCA web application locally
+## Running the ORCA web application
+
+### Running locally
 
 Navigate to the [github-metrics](/github-metrics) subdirectory. If you have not installed
 [Gatsby](https://www.gatsbyjs.com/docs/tutorial/getting-started/part-0/), do so, and then run
@@ -13,7 +15,10 @@ gatsby clean
 gatsby develop
 ```
 
-To update the production website, run `gatsby clean; gatsby build` and then `bash push_to_production.sh`.
+### Deploying to production
+
+To update the production website, run `bash push_to_production.sh` to build the
+site, push it to the production bucket, and update tags in the repository.
 
 ## Running data retrieval scripts
 

--- a/github-metrics/push_to_production.sh
+++ b/github-metrics/push_to_production.sh
@@ -1,1 +1,8 @@
-gsutil -m rsync -r -d public "gs://eto-tmp/eto-orca/public" && gsutil -m -h "Cache-Control:no-cache, max-age=0" rsync -r -d "gs://eto-tmp/eto-orca/public" "gs://orca.eto.tech/"
+npm install && \
+gatsby clean && \
+npm run build && \
+gsutil -m rsync -r -d public "gs://eto-tmp/eto-orca/public" && \
+gsutil -m -h "Cache-Control:no-cache, max-age=0" rsync -r -d "gs://eto-tmp/eto-orca/public" "gs://orca.eto.tech/" && \
+git tag --force deploy/previous deploy/current && \
+git tag --force deploy/current HEAD && \
+git push -f origin deploy/previous deploy/current


### PR DESCRIPTION
Format the deploy script so that each command is on its own line. Add commands to tag the previously-deployed and just-deployed commits and push the tags to the repo.  Update README section on deployments.